### PR TITLE
Support for Alias on the Root Command

### DIFF
--- a/pkg/hypercmd/command.go
+++ b/pkg/hypercmd/command.go
@@ -65,6 +65,13 @@ func (h *HyperCommand) Resolve(allArgs []string, withAliases bool) (*cobra.Comma
 	if h.root.Name() == name {
 		return h.root, nil
 	}
+	if withAliases {
+		for _, alias := range h.root.Aliases {
+			if alias == name {
+				return h.root, nil
+			}
+		}
+	}
 
 	// Reinject the root command name into the arguments, because (cobra.Command).Execute
 	// always traverses to the root before execution, even when we want a subcommand

--- a/pkg/testrunner/testdata/scripts/simple.txtar
+++ b/pkg/testrunner/testdata/scripts/simple.txtar
@@ -3,6 +3,14 @@ exec testrunner
 stdout 'Run a command in testrunner'
 ! stderr .
 
+# succeeds running as alias
+exec testrunner.wasm
+stdout 'Run a command in testrunner'
+! stderr .
+
+# fails running as alias without alias support enabled
+! exec testrunner.false
+
 # succeeds running version
 exec testrunner version
 ! stdout .

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -9,24 +9,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func RunCode() int {
+func RunCode() {
 	if err := Run(false); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
-		return 1
 	}
 
-	return 0
+	os.Exit(0)
 }
 
-func RunCodeWithAliases() int {
+func RunCodeWithAliases() {
 	if err := Run(true); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
-		return 1
 	}
 
-	return 0
+	os.Exit(0)
 }
 
 func Run(setAliases bool) error {

--- a/pkg/testrunner/testrunner.go
+++ b/pkg/testrunner/testrunner.go
@@ -10,7 +10,7 @@ import (
 )
 
 func RunCode() int {
-	if err := Run(); err != nil {
+	if err := Run(false); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 		return 1
@@ -19,8 +19,21 @@ func RunCode() int {
 	return 0
 }
 
-func Run() error {
+func RunCodeWithAliases() int {
+	if err := Run(true); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+		return 1
+	}
+
+	return 0
+}
+
+func Run(setAliases bool) error {
 	root := hypercmd.New("testrunner")
+	if setAliases {
+		root.Root().Aliases = []string{"testrunner.wasm", "testrunner.false"}
+	}
 	root.Root().SilenceErrors = true
 	root.Root().SilenceUsage = true
 

--- a/pkg/testrunner/testrunner_test.go
+++ b/pkg/testrunner/testrunner_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testscript.RunMain(m, map[string]func() int{
+	testscript.Main(m, map[string]func(){
 		"testrunner": RunCode,
 		"add":        RunCode,
 		"multiply":   RunCode,

--- a/pkg/testrunner/testrunner_test.go
+++ b/pkg/testrunner/testrunner_test.go
@@ -12,6 +12,9 @@ func TestMain(m *testing.M) {
 		"add":        RunCode,
 		"multiply":   RunCode,
 		"version":    RunCode,
+
+		"testrunner.false": RunCode,
+		"testrunner.wasm":  RunCodeWithAliases,
 	})
 }
 


### PR DESCRIPTION
When `Aliases` is set on the root command and `withAliases` is true, allow matching against any alias. This is useful in cases where the program is compiled to wasm, where the binary has a `.wasm` suffix, though there may be other legitimate usecases as well.